### PR TITLE
Fetch PR counts and author avatar URLs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+GHTOKEN=abcde
+AUTHORS=user1:user2:user3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+*.swp
+hacktoberfest-leaderboard

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM golang:1.13-alpine
+FROM golang:1.13-alpine as builder
 
 COPY . /app
 WORKDIR /app
 RUN go build
+
+FROM alpine
+COPY --from=builder /app /app
 ENTRYPOINT ["/app/hacktoberfest-leaderboard"]
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.13-alpine
+
+COPY . /app
+WORKDIR /app
+RUN go build
+ENTRYPOINT ["/app/hacktoberfest-leaderboard"]
+EXPOSE 4000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# hacktoberfest-leaderboard
+# Hacktoberfest Leaderboard
+
+Get the PR counts and avatar URLs for a list of authors defined in the `AUTHORS` environment variable and return as JSON.
+
+## Building and Running
+
+Install [Docker](https://docs.docker.com/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
+
+Run `docker-compose up`. Use `docker-compose up --build` if the image needs to be rebuilt.
+
+## Environment Variables
+
+Copy `.env.sample` to `.env`.
+
+To increase GitHub's rate limit and allow up to 30 authors on the leaderboard, obtain a [personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) from GitHub.
+Without the token, only 10 authors can be added as the [search API's rate limit](https://developer.github.com/v3/search/#rate-limit) will be reached.
+
+Assign the personal access token to the `GHTOKEN` variable.
+Add the authors to be included on the leaderboard to the `AUTHORS` variable, separated by the colon character `:`.
+
+## Retrieving Data
+
+With the Docker container running, open a browser and go to [https://localhost:4000/leaderboard](https://localhost:4000/leaderboard).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  backend:
+    build: .
+    ports:
+      - "4000:4000"
+    environment:
+      - GHTOKEN=${GHTOKEN}
+      - AUTHORS=${AUTHORS}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/moexmen/hacktoberfest-leaderboard
+
+go 1.12
+
+require github.com/caarlos0/env v3.5.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/caarlos0/env v3.5.0+incompatible h1:Yy0UN8o9Wtr/jGHZDpCBLpNrzcFLLM2yixi/rBrKyJs=
+github.com/caarlos0/env v3.5.0+incompatible/go.mod h1:tdCsowwCzMLdkqRYDlHpZCp2UooDD3MspDBjZ2AD02Y=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+type UserData struct {
+	PrCount   int
+	AvatarURL string
+}
+
+type avatarResult struct {
+	AvatarURL string `json:"avatar_url"`
+}
+
+type prCountResult struct {
+	PrCount int `json:"total_count"`
+}
+
+func leaderboard(writer http.ResponseWriter, request *http.Request) {
+	userData := make(map[string]UserData)
+	authors := []string{"teo-shaowei", "fonglh", "cflee", "naomilwx", "jchiam", "jeremyyap", "wongherlung", "xeluna", "weelillad"}
+	for _, author := range authors {
+		userData[author] = UserData{PrCount: getPrCount(author), AvatarURL: getAvatar(author)}
+	}
+	jsonString, _ := json.Marshal(userData)
+	fmt.Fprintf(writer, "%s", jsonString)
+}
+
+func getAvatar(author string) string {
+	url := fmt.Sprintf("https://api.github.com/users/%s", author)
+	response, err := http.Get(url)
+	if response != nil {
+		defer response.Body.Close()
+	}
+	if err != nil {
+		fmt.Println("Failed to fetch avatar. %s\n", err)
+		return ""
+	} else {
+		ghData, _ := ioutil.ReadAll(response.Body)
+		result := avatarResult{}
+		json.Unmarshal([]byte(ghData), &result)
+		return result.AvatarURL
+	}
+}
+
+func getPrCount(author string) int {
+	year := calcYear()
+	url := fmt.Sprintf("https://api.github.com/search/issues?q=created:%d-09-30T00:00:00-12:00..%d-10-31T23:59:59-12:00+type:pr+is:public+author:%s", year, year, author)
+	client := &http.Client{}
+	request, _ := http.NewRequest("GET", url, nil)
+	if cfg.GithubToken != "" {
+		request.Header.Set("Authorization", "token "+cfg.GithubToken)
+	}
+	response, err := client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
+	if err != nil {
+		fmt.Println("The HTTP request failed with error %s\n", err)
+		return 0
+	} else {
+		ghData, _ := ioutil.ReadAll(response.Body)
+		result := prCountResult{}
+		json.Unmarshal([]byte(ghData), &result)
+		return result.PrCount
+	}
+}
+
+func calcYear() int {
+	currentTime := time.Now()
+	dateTimeString := fmt.Sprintf("30 Sep %d 0:00 -1200", currentTime.Year()-2000)
+	hacktoberfestStart, _ := time.Parse(time.RFC822Z, dateTimeString)
+	if currentTime.Before(hacktoberfestStart) {
+		return currentTime.Year() - 1
+	} else {
+		return currentTime.Year()
+	}
+}
+
+func main() {
+	http.HandleFunc("/leaderboard", leaderboard)
+	http.ListenAndServe(":4000", nil)
+}

--- a/main.go
+++ b/main.go
@@ -3,10 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/caarlos0/env"
 	"io/ioutil"
 	"net/http"
 	"time"
 )
+
+type config struct {
+	GithubToken string `env:"GHTOKEN"`
+	Authors     string `env:"AUTHORS"`
+}
 
 type UserData struct {
 	PrCount   int
@@ -83,6 +89,12 @@ func calcYear() int {
 }
 
 func main() {
+	cfg := config{}
+	if err := env.Parse(&cfg); err != nil {
+		fmt.Printf("%+v\n", err)
+	}
+	fmt.Printf("%+v\n", cfg)
+
 	http.HandleFunc("/leaderboard", leaderboard)
 	http.ListenAndServe(":4000", nil)
 }


### PR DESCRIPTION
Return the data as JSON.

Allows GitHub personal authorization tokens to be specified to increase the [search rate limit](https://developer.github.com/v3/search/#rate-limit) from 10 to 30.

Both auth token and author list are given as env vars. When used with the provided `Dockerfile` and `docker-compose.yml` files, these variables can be easily specified with a `.env` file.
